### PR TITLE
workaround for spinning  when array is decreasing

### DIFF
--- a/docs/presentation-order/data/generator.json
+++ b/docs/presentation-order/data/generator.json
@@ -1,10 +1,13 @@
 {
   "start": ["Make something with an #input# and an #output#."],
   "input": [
-    "Group 1",
-    "Group 2",
-    "Group 3",
-    "Group 4"
+    "Hayden & Dorian",
+    "Yiru & Maria",
+    "Enrique & Steven",
+    "Parisa & Po-Wen",
+    "Christopher, Christina",
+    "Wenye, Adam, & Hongyi",
+    "Ivy and Michael"
   ],
   "output": [
     "Ghost 👻",

--- a/docs/presentation-order/sketch.js
+++ b/docs/presentation-order/sketch.js
@@ -39,9 +39,10 @@ function setup() {
 
 function draw() {
 
-  if (inputWheel.spin) {
-    inputWheel.move();
-  }
+  // workaround, see line 69
+  // if (inputWheel.spin) {
+  //   // inputWheel.move();
+  // }
   if (outputWheel.spin) {
     outputWheel.move();
   }
@@ -65,9 +66,10 @@ function startSpin(
 ) {
   isSpinning = true;
 
-  inputWheel.target = targetInput;
-  inputWheel.spin = true;
-  inputWheel.resetAriaHidden();
+  // inputWheel.target = targetInput; // not the target that displays!!
+  // inputWheel.spin = true;
+  inputWheel.update(targetInput);
+  // inputWheel.resetAriaHidden();
 
   outputWheel.target = targetOutput;
   outputWheel.spin = true;
@@ -80,7 +82,7 @@ function startSpin(
   //     data.output[targetOutput]
   // );
 
-  // remove data point here?
+  // remove data from array here
   console.log(data.input[targetInput]);
   data.input.splice(targetInput, 1);
   console.log(data.input);

--- a/docs/presentation-order/wheel.js
+++ b/docs/presentation-order/wheel.js
@@ -38,9 +38,22 @@ class Wheel {
             this.elements[i].style('visibility', 'visible');
         }
     }
+
+    // continuing the hack workaround
+    update(target) {
+        console.log(data.input[target]);
+        let inputWheel = document.getElementById("inputs");
+        inputWheel.innerHTML = data.input[target];
+        inputWheel.style.position = "relative";
+        inputWheel.style.top = "45%"
+        this.spin = false;
+
+    }
+
     move() {
         this.currTop -= this.speed;
-
+        // console.log(this.target);
+        // console.log(this.currentIndex);
         this.difference = int(this.target) - int(this.currentIndex);
         this.speed = 60 * abs((this.difference) % (this.data.length * this.numOfCycles * 2)) / (this.data.length*this.numOfCycles * 2);
 


### PR DESCRIPTION
This PR for the presentation-order spinner: 
- adds names of participating group members to "group" wheel
- provides a workaround for randomly displaying groups on the  "group" wheel without repeat
- continues the tradition of last minute hacky workarounds for an ITP/IMA event